### PR TITLE
[fix][program-service] 다수 스케줄 메시지 멱등성 보장을 위해 넘기는 correlationId 값 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '4.0.0'
 }
 
 group = 'com.firstticket'
@@ -47,6 +48,13 @@ repositories {
         }
     }
     maven {
+        url = 'https://maven.pkg.github.com/first-ticket/common-jpa'
+        credentials {
+            username = githubUser
+            password = githubToken
+        }
+    }
+    maven {
         url = 'https://maven.pkg.github.com/first-ticket/common-messaging'
         credentials {
             username = githubUser
@@ -55,8 +63,13 @@ repositories {
     }
 }
 
+configurations {
+    asciidoctorExt
+}
+
 ext {
     set('springCloudVersion', "2025.0.2")
+    snippetsDir = file("build/generated-snippets")
 }
 
 dependencyManagement {
@@ -68,8 +81,8 @@ dependencyManagement {
 dependencies {
     // first-ticket 공통 모듈
     implementation 'com.first-ticket:common:0.0.4-SNAPSHOT'
-    implementation 'com.first-ticket:common-jpa:0.0.1-SNAPSHOT'
-    implementation 'com.first-ticket:common-messaging:0.0.1-SNAPSHOT'
+    implementation 'com.first-ticket:common-jpa:0.0.2-SNAPSHOT'
+    implementation 'com.first-ticket:common-messaging:0.0.2-SNAPSHOT'
 
     // ── Spring Boot Core & Common ──
 //    implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -122,6 +135,7 @@ dependencies {
     testImplementation 'com.h2database:h2'
 
     // Rest Docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
@@ -141,5 +155,36 @@ clean {
 }
 
 test {
+    outputs.dir snippetsDir          // 스니펫을 snippetsDir에 저장
     useJUnitPlatform()
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test
+    configurations 'asciidoctorExt'
+    baseDirFollowsSourceFile()
+}
+
+tasks.named('asciidoctor') {
+    doFirst {
+        delete file('src/main/resources/static/docs')
+    }
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from layout.buildDirectory.dir("docs/asciidoc")
+    into layout.projectDirectory.dir("src/main/resources/static/docs")
+}
+
+tasks.named('build') {
+    dependsOn copyDocument
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from(layout.buildDirectory.dir("docs/asciidoc")) {
+        into 'static/docs'
+    }
 }

--- a/src/main/java/com/firstticket/programservice/domain/Program.java
+++ b/src/main/java/com/firstticket/programservice/domain/Program.java
@@ -263,10 +263,6 @@ public class Program extends BaseUserEntity {
         if (type == null) {
             throw new ProgramException(ProgramErrorCode.INVALID_PROGRAM_TYPE);
         }
-        // region은 생성 시점에 확정되며 이후 변경하지 않는다
-        if (region == null || region.isBlank()) {
-            throw new ProgramException(ProgramErrorCode.INVALID_REGION);
-        }
 
         if (region.length() > 100) {
             throw new ProgramException(ProgramErrorCode.INVALID_REGION);
@@ -275,6 +271,7 @@ public class Program extends BaseUserEntity {
     }
 
     private static String normalizeRegion(String region) {
+        // region은 생성 시점에 확정되며 이후 변경하지 않는다
         if (region == null || region.isBlank()) {
             throw new ProgramException(ProgramErrorCode.INVALID_REGION);
         }

--- a/src/main/java/com/firstticket/programservice/domain/Schedule.java
+++ b/src/main/java/com/firstticket/programservice/domain/Schedule.java
@@ -160,10 +160,10 @@ public class Schedule extends BaseUserEntity {
         LocalDateTime newSaleEnd = (saleEndAt != null) ? saleEndAt : this.saleEndAt;
 
         // 새로 입력된 판매 기간이 현재 시각보다 이전이면 차단
-        if (newSaleStart.isBefore(currentTime)) {
+        if (saleStartAt != null && newSaleStart.isBefore(currentTime)) {
             throw new ProgramException(ProgramErrorCode.INVALID_SALE_PERIOD);
         }
-        if (newSaleEnd.isBefore(currentTime)) {
+        if (saleEndAt != null && newSaleEnd.isBefore(currentTime)) {
             throw new ProgramException(ProgramErrorCode.INVALID_SALE_PERIOD);
         }
 
@@ -182,7 +182,7 @@ public class Schedule extends BaseUserEntity {
 
         // 이미 등록된 스케줄의 eventStartAt이 현재 시각보다 이전일 수 있으므로
         // 변경하지 않는다면 과거 시점 판정을 하지 않음
-        if (eventStartAt != null && newEventStart.isBefore(LocalDateTime.now())) {
+        if (eventStartAt != null && newEventStart.isBefore(currentTime)) {
             throw new ProgramException(ProgramErrorCode.PAST_EVENT_START);
         }
 

--- a/src/main/java/com/firstticket/programservice/domain/service/dto/ScheduleRemainingData.java
+++ b/src/main/java/com/firstticket/programservice/domain/service/dto/ScheduleRemainingData.java
@@ -2,6 +2,9 @@ package com.firstticket.programservice.domain.service.dto;
 
 import java.util.UUID;
 
+import com.firstticket.programservice.domain.exception.ProgramErrorCode;
+import com.firstticket.programservice.domain.exception.ProgramException;
+
 /**
  * 좌석 서비스에서 조회한 회차별 잔여 좌석 수 데이터.
  * SeatProvider를 통해 조회된 결과를 담는다.
@@ -13,7 +16,7 @@ public record ScheduleRemainingData(
 ) {
     public ScheduleRemainingData {
         if (scheduleId == null) {
-            throw new NullPointerException("scheduleId는 null일 수 없습니다.");
+            throw new ProgramException(ProgramErrorCode.INVALID_SCHEDULE_ID);
         }
         if (remainingCount < 0) {
             throw new IllegalArgumentException("remainingCount는 0 이상이어야 합니다.");

--- a/src/main/java/com/firstticket/programservice/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/firstticket/programservice/infrastructure/config/JpaConfig.java
@@ -1,0 +1,16 @@
+package com.firstticket.programservice.infrastructure.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = {
+    "com.firstticket.programservice",
+    "com.firstticket.common.messaging"
+})
+@EnableJpaRepositories(basePackages = {
+    "com.firstticket.programservice",
+    "com.firstticket.common.messaging"
+})
+public class JpaConfig {}

--- a/src/main/java/com/firstticket/programservice/infrastructure/event/ProgramEventPublisherImpl.java
+++ b/src/main/java/com/firstticket/programservice/infrastructure/event/ProgramEventPublisherImpl.java
@@ -78,7 +78,7 @@ public class ProgramEventPublisherImpl implements ProgramEventPublisher {
             .toList();
 
         Events.publish(
-            UUID.randomUUID().toString(),
+            schedule.getId() + "-" + scheduleCreated,
             "SCHEDULE",
             schedule.getId(),
             scheduleCreated,

--- a/src/main/resources/db/migration/V1__init_program.sql
+++ b/src/main/resources/db/migration/V1__init_program.sql
@@ -1,7 +1,7 @@
 -- =====================================================
 -- Program Service — V1 초기 스키마
--- schema: program.schema
--- Spring 설정: spring.jpa.properties.hibernate.default_schema=program.schema
+-- schema: program_schema
+-- Spring 설정: spring.jpa.properties.hibernate.default_schema=program_schema
 -- =====================================================
 
 -- ── btree_gist 확장 ──────────────────────────────────

--- a/src/main/resources/db/migration/V1__init_program.sql
+++ b/src/main/resources/db/migration/V1__init_program.sql
@@ -1,7 +1,7 @@
 -- =====================================================
 -- Program Service — V1 초기 스키마
--- schema: program
--- Spring 설정: spring.jpa.properties.hibernate.default_schema=program
+-- schema: program.schema
+-- Spring 설정: spring.jpa.properties.hibernate.default_schema=program.schema
 -- =====================================================
 
 -- ── btree_gist 확장 ──────────────────────────────────


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 다수 스케줄 생성 후 판매 시 발행하는 schedule.created 메세지의 correlationId 값 수정


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- #22 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- schedule.created 메세지의 correlationId 값 수정됨


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->